### PR TITLE
Add Setting for --include-checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,24 @@ For general information on how SublimeLinter works with settings, please see [Se
 
 You can configure `cfn-lint` by adding the following options to the Sublime Linter User Settings:
 
-* ignore_rules: Array of rules that should be ignored when testing the file
-* append_rules: Array of paths containing additional rules to be applied
-* override_spec: Path the a Specification Override file
+* `ignore_rules`: Array of rules that should be ignored when testing the file
+* `append_rules`: Array of paths containing additional rules to be applied
+* `override_spec`: Path the a Specification Override file
+* `include_checks`: Array of rules that should be included when testing the file
+    * This setting requires v0.8.0 or later.
 
 Example:
 
 ```json
 {
   "linters": {
-	  "cfnlint": {
-	    "ignore_rules": ["W2507", "W2508"],
-	    "append_rules": ["/path/to/custom/rules"],
-	    "override_spec": "/path/to/override.json"
-	  }
-	}
+    "cfnlint": {
+      "ignore_rules": ["W2507", "W2508"],
+      "append_rules": ["/path/to/custom/rules"],
+      "override_spec": "/path/to/override.json",
+      "include_checks": ["I"]
+    }
+  }
 }
 ```
 

--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,7 @@ class CfnLint(Linter):
     """Provides an interface to cfn-lint."""
 
     cmd = ('cfn-lint', '--template', '${file}', '--format', 'parseable')
-    regex = r'^.+?:(?P<line>\d+):(?P<col>\d+):\d+:\d+:((?P<warning>W)|(?P<error>E))(?P<code>.{4}):(?P<message>.+)'
+    regex = r'^.+?:(?P<line>\d+):(?P<col>\d+):\d+:\d+:((?P<warning>W|I)|(?P<error>E))(?P<code>.{4}):(?P<message>.+)'
     multiline = True
     line_col_base = (1, 1)
     tempfile_suffix = '-'
@@ -67,5 +67,15 @@ class CfnLint(Linter):
             if override_spec:
                 cmd.append('--override-spec')
                 cmd.append(override_spec)
+
+            include_checks = self.settings.get('include_checks', [])
+            if len(include_checks) > 0:
+
+                cmd.append('--include-checks')
+
+                for include_rule in include_checks:
+                    cmd.append(include_rule)
+
+            print(cmd)
 
             return super().communicate(cmd, code)

--- a/linter.py
+++ b/linter.py
@@ -44,10 +44,8 @@ class CfnLint(Linter):
                 is_cfn = True
 
         if is_cfn:
-            settings = self.get_view_settings()
-
             # Add ignore rules
-            ignore_rules = settings.get('ignore_rules', [])
+            ignore_rules = self.settings.get('ignore_rules', [])
             if len(ignore_rules) > 0:
 
                 cmd.append('--ignore-checks')
@@ -56,7 +54,7 @@ class CfnLint(Linter):
                     cmd.append(ignore_rule)
 
             # Add apprent rules paths
-            append_rules = settings.get('append_rules', [])
+            append_rules = self.settings.get('append_rules', [])
             if len(append_rules) > 0:
 
                 cmd.append('--append-rules')
@@ -64,9 +62,8 @@ class CfnLint(Linter):
                 for append_rule in append_rules:
                     cmd.append(append_rule)
 
-            # Add override spdcificaton file
-            override_spec = settings.get('override_spec')
-
+            # Add override specification file
+            override_spec = self.settings.get('override_spec')
             if override_spec:
                 cmd.append('--override-spec')
                 cmd.append(override_spec)

--- a/linter.py
+++ b/linter.py
@@ -12,11 +12,11 @@ from SublimeLinter.lint import Linter, util
 
 import re
 
+
 class CfnLint(Linter):
     """Provides an interface to cfn-lint."""
 
     cmd = ('cfn-lint', '--template', '${file}', '--format', 'parseable')
-    executable = None
     regex = r'^.+?:(?P<line>\d+):(?P<col>\d+):\d+:\d+:((?P<warning>W)|(?P<error>E))(?P<code>.{4}):(?P<message>.+)'
     multiline = True
     line_col_base = (1, 1)
@@ -33,7 +33,7 @@ class CfnLint(Linter):
         """Run an external executable using stdin to pass code and return its output."""
         relfilename = self.filename
 
-        is_cfn = False;
+        is_cfn = False
 
         # Check if we're processing a CloudFormation file
         with open(relfilename, 'r', encoding='utf8') as file:
@@ -41,7 +41,7 @@ class CfnLint(Linter):
             regex = re.compile(r'"?AWSTemplateFormatVersion"?\s*')
 
             if regex.search(content):
-                is_cfn = True;
+                is_cfn = True
 
         if is_cfn:
             settings = self.get_view_settings()

--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,11 @@ class CfnLint(Linter):
     """Provides an interface to cfn-lint."""
 
     cmd = ('cfn-lint', '--template', '${file}', '--format', 'parseable')
-    regex = r'^.+?:(?P<line>\d+):(?P<col>\d+):\d+:\d+:((?P<warning>W|I)|(?P<error>E))(?P<code>.{4}):(?P<message>.+)'
+    regex = (
+        r'^.+?:(?P<line>\d+):(?P<col>\d+):\d+:\d+:'
+        r'((?P<warning>W|I)|(?P<error>E))(?P<code>.{4})'
+        r':(?P<message>.+)'
+    )
     multiline = True
     line_col_base = (1, 1)
     tempfile_suffix = '-'
@@ -68,6 +72,7 @@ class CfnLint(Linter):
                 cmd.append('--override-spec')
                 cmd.append(override_spec)
 
+            # Add additional checks
             include_checks = self.settings.get('include_checks', [])
             if len(include_checks) > 0:
 
@@ -75,7 +80,5 @@ class CfnLint(Linter):
 
                 for include_rule in include_checks:
                     cmd.append(include_rule)
-
-            print(cmd)
 
             return super().communicate(cmd, code)


### PR DESCRIPTION
Adds a new `include_checks` array setting that corresponds to the `--include-checks` CLI option. This allows you to enable the [information](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/docs/rules.md#informational) checks — which are disabled by default.

---

I also cleaned up 2 different warnings being emitted by the ST console:

- Remove `cls.executable` property, as it has no effect.
- Use `self.settings` directly instead of calling `self.get_view_settings()`.